### PR TITLE
Remove filemod modification on config loading

### DIFF
--- a/usr/lib/linuxmuster-webui/plugins/lmn_common/api.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_common/api.py
@@ -37,8 +37,6 @@ class LinuxmusterConfig():
         return self.path
 
     def load(self):
-        if os.geteuid() == 0:
-            os.chmod(self.path, 384)  # 0o600
         self.data = yaml.load(open(self.path))
 
     def save(self):


### PR DESCRIPTION
Sometimes, when file rights changed because of root user, the users which working in own user context, doesn't have the permission to read config files.