### PR TITLE
Add additional_builtins in deepsource config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,3 +8,4 @@ enabled = true
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+  additional_builtins = ["_"]


### PR DESCRIPTION
This PR adds `_` as an additional-builtin in the DeepSource config to take care of the false-positives raised for it. 