### PR TITLE
Always upload release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
         run: rm ./current-changes
 
       - name: Upload Release Assets
-        if: env.DISTRIBUTION == 'lmn70'
         id: upload-release-assets
         uses: dwenegar/upload-release-assets@v1
         env:


### PR DESCRIPTION
Hi @kiarn 

I think, release assets can always be uploaded, also for testing releases.
Or am I missing something?

Regards,
Dorian