### PR TITLE
feat: Detect OS Windows

### DIFF
--- a/usr/lib/linuxmuster-webui/plugins/lmn_linbo_sync/api.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_linbo_sync/api.py
@@ -274,7 +274,7 @@ def is_port_signature_windows(ports):
     """
     return (
         "135" in ports
-        and ports["135"] == "open"
+        and ports["135"]in ["open", "filtered"]
         and (
             "22" not in ports
             or ports["22"] != "open"


### PR DESCRIPTION
This PR improves the OS detection in linbo_sync by adding windows to the detectable OSs.
![image](https://user-images.githubusercontent.com/30153207/148641813-4ccaafa3-b6ce-473f-a0bb-f82eb6458db1.png)
Before, Windows was detected as Linbo.

What do you think?
I have one question: I import the module `xml.etree.ElementTree`, do we need to add this to the requirements.txt?

Regards,
Dorian