### PR TITLE
Remove unecessary users in ACLs

### DIFF
--- a/usr/lib/linuxmuster-webui/etc/webuiUpload.ntacl
+++ b/usr/lib/linuxmuster-webui/etc/webuiUpload.ntacl
@@ -4,10 +4,6 @@
 user::rwx
 user:root:rwx
 user:3000000:rwx
-user:3000225:rwx
-user:3000226:rwx
-user:3000238:rwx
-user:3000496:rwx
 group::---
 group:users:---
 group:LINUXMUSTER\134admins:rwx
@@ -17,10 +13,6 @@ other::---
 default:user::rwx
 default:user:root:rwx
 default:user:3000000:rwx
-default:user:3000225:rwx
-default:user:3000226:rwx
-default:user:3000238:rwx
-default:user:3000496:rwx
 default:group::---
 default:group:users:---
 default:group:LINUXMUSTER\134admins:rwx


### PR DESCRIPTION
I don't see why these id are necessary for the installation, and there are actually colliding with real users in my installation, so I would recommend to remove it, or to clarify why there are these entries.