### PR TITLE
Fixed looking for dfs proxies

### DIFF
--- a/usr/lib/linuxmuster-webui/plugins/lmn_common/multischool.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_common/multischool.py
@@ -67,8 +67,8 @@ class SchoolManager():
         config = ConfigObj(StringIO(check_output(["/usr/bin/net", "conf", "list"], shell=False).decode()))
         for share_name, share_config in config.items():
             # DFS activated ?
-            if share_config.get('msdfs_root', 'no') == 'yes':
-                dfs_proxy = share_config.get('msdfs_proxy', '')
+            if share_config.get('msdfs root', 'no') == 'yes':
+                dfs_proxy = share_config.get('msdfs proxy', '')
                 if dfs_proxy != '':
                     # //sub.domain.lan/school to \\\\sub.domain.lan\\school
                     self.dfs[share_name] = {


### PR DESCRIPTION
Minor mistake in asking for the values of msdfs root and msdfs proxy. These keys do in fact contain a whitespace instead of an underscore 

[default-school]
        msdfs root = yes
        msdfs proxy = //file01.linuxmuster.lan/default-school
        hide unreadable = yes