### PR TITLE
Add wireguard-plugin to linuxmuster-webui

### DIFF
--- a/usr/lib/linuxmuster-webui/plugins/lmn_common/api.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_common/api.py
@@ -35,6 +35,7 @@ if os.path.isfile(config_path):
         # Display options
         display_options = lmconfig['linuxmuster'].get('display', {})
         display_options['show_webdav'] = display_options.get('show_webdav', True)
+        display_options['show_wireguard'] = display_options.get('show_wireguard', False)
 
         # Roles auth
         auth_config = lmconfig['linuxmuster'].get('auth', {})

--- a/usr/lib/linuxmuster-webui/plugins/lmn_common/resources/build/all.css
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_common/resources/build/all.css
@@ -171,8 +171,7 @@ html body.customized *[checkbox].active i.on {
 }
 
 html body.customized smart-progress .progress .progress-bar-warning {
-  background: #ffab40;
-  /*#DC6D1D;*/
+  background: #ffab40; /*#DC6D1D;*/
 }
 html body.customized smart-progress .progress .progress-bar-danger {
   background: #d9534a;

--- a/usr/lib/linuxmuster-webui/plugins/lmn_landingpage/resources/partial/index.html
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_landingpage/resources/partial/index.html
@@ -118,6 +118,43 @@
                     </ul>
                 </div>
             </div>
+
+            <div class="panel panel-info" ng:if="show_wireguard">
+                <div class="panel-heading">
+                    <h4 translate>Wireguard VPN</h4>
+                </div>
+                <div class="panel-body">
+                    <p translate>
+                        You can access the school network by using wireguard. You can download the client for the
+                        following operating systems:
+                    </p>
+                    <a href="https://download.wireguard.com/windows-client/wireguard-installer.exe" target="_blank" style="margin-right: 10px;" title="Windows">
+                        <i class="fab fa-windows fa-3x"></i>
+                    </a>
+                    <a href="https://www.wireguard.com/install/" target="_blank" style="margin-right: 10px;" title="Linux">
+                        <i class="fab fa-linux fa-3x"></i>
+                    </a>
+                    <a href="https://play.google.com/store/apps/details?id=com.wireguard.android" target="_blank" style="margin-right: 10px;" title="Android">
+                        <i class="fab fa-android fa-3x"></i>
+                    </a>
+                    <a href="https://itunes.apple.com/us/app/wireguard/id1441195209?ls=1&mt=8" target="_blank" style="margin-right: 10px;" title="iOS">
+                        <i class="fab fa-apple fa-3x"></i>
+                    </a>
+
+                    <a ng:click="showWireguardQR()" class="pull-right" style="margin-right: 10px;" title="Show QR-Code">
+                        <i class="fa fa-qrcode fa-3x"></i>
+                    </a>
+                    <a ng:click="showWireguardConfig()" class="pull-right" style="margin-right: 10px;" title="Show Configuration">
+                        <i class="fa fa-download fa-3x"></i>
+                    </a>
+
+                    <div class="alert alert-success" role="alert" ng:if="wireguardConnectionStatus.status == 'connected'" style="margin-top: 20px;">
+                        <b translate>Endpoint</b>: {{wireguardConnectionStatus.endpoint}}
+                        <b translate>Last Handshake</b>: {{wireguardConnectionStatus.latest_handshake_difference | number:0}} <span translate></span>seconds ago</span> | 
+                        <i class="fa fa-arrow-down"></i> {{wireguardConnectionStatus.transfer.received | number:2}} MiB | <i class="fa fa-arrow-up"></i> {{wireguardConnectionStatus.transfer.send | number:2}} MiB
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/.gitignore
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/.gitignore
@@ -1,0 +1,57 @@
+build
+vendor
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/README.md
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/README.md
@@ -1,0 +1,17 @@
+# Linuxmuster Wireguard VPN Manager
+
+## Configuration
+
+You need a configfile like the following:
+
+`/etc/linuxmuster/webui/wireguard/config.json`:
+    {
+        "url": "http://10.0.0.3:8000",
+        "secret": "1234567890"
+    }
+
+`/etc/linuxmuster/webui/config.yml`:
+    linuxmuster:
+        [...]
+        display:
+            show_wireguard: true

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/__init__.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/__init__.py
@@ -1,0 +1,5 @@
+import logging
+from .main import ItemProvider
+from .views import Handler
+
+logging.info('lmn_wireguard.__init__.py: lmn_wireguard loaded')

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/main.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/main.py
@@ -1,0 +1,35 @@
+from jadi import component
+
+from aj.plugins.core.api.sidebar import SidebarItemProvider
+
+
+@component(SidebarItemProvider)
+class ItemProvider(SidebarItemProvider):
+    def __init__(self, context):
+        pass
+
+    def provide(self):
+        return [
+            {
+                # category:tools, category:sofware, category:system, category:other
+                'attach': 'category:software',
+                'name': 'Wireguard',
+                # https://fontawesome.com/icons/
+                'icon': 'network-wired',
+                'url': '/view/lmn/wireguard',
+                'children': []
+            }
+        ]
+
+# Uncomment the following lines to set a new permission
+# from aj.auth import PermissionProvider
+# @component(PermissionProvider)
+# class Permissions (PermissionProvider):
+#     def provide(self):
+#         return [
+#             {
+#                 'id': 'lmn_wireguard:show',
+#                 'name': _('Show the Python binding example'),
+#                 'default': False,
+#             },
+#         ]

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/permissions.yml
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/permissions.yml
@@ -1,0 +1,8 @@
+globaladministrator:
+- 'sidebar:view:/view/lmn/wireguard: true'
+schooladministrator:
+- 'sidebar:view:/view/lmn/wireguard: true'
+student:
+- 'sidebar:view:/view/lmn/wireguard: false'
+teacher:
+- 'sidebar:view:/view/lmn/wireguard: false'

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/plugin.yml
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/plugin.yml
@@ -1,0 +1,22 @@
+name: lmn_wireguard
+author: Lukas Spitznagel
+email: lukas.spitznagel@netzint.de
+url: https://netzint.de
+version: '1.0'
+title: 'Wireguard'
+icon: network-wired
+# dependency on Core is required for UI plugins
+dependencies:
+    - !PluginDependency {
+        plugin_name: core
+    }
+    - !PluginDependency { 
+        plugin_name: lmn_common 
+    }
+resources:
+    - 'resources/js/module.es'
+    - 'resources/js/routing.es'
+    - 'resources/js/controllers/index.controller.es'
+    - 'resources/partial/index.html'
+    - 'resources/partial/import.modal.html'
+    - 'ng:lmn.wireguard'

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/js/controllers/index.controller.es
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/js/controllers/index.controller.es
@@ -1,0 +1,185 @@
+angular.module('lmn.wireguard').controller('Lmn_wireguardIndexController', function($scope, $http, $uibModal, pageTitle, gettext, notify, messagebox) {
+    pageTitle.set(gettext('Wireguard'));
+
+    $scope.status = {};
+
+    $scope.loadPeers = () => {
+        $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers", "method": "GET" }).then( (resp) => {
+            $scope.peers = resp.data;
+            $scope.loadStatus();
+        });
+    }
+
+    $scope.loadStatus = () => {
+        $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers/status", "method": "GET" }).then( (resp) => {
+            $scope.status = resp.data;
+            console.log(resp.data);
+        }); 
+    }
+
+    $scope.showConfig = (peer) => {
+        $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers/" + peer + "/config", "method": "GET" }).then( (resp) => {
+            $uibModal.open({
+                template: "<div style='margin:10px;'><h2>Wireguard-Konfiguration \"" + peer + "\"</h2><pre>" + resp.data.data + "</pre></div>",
+                size: 'mg'
+            });
+        });
+    }
+
+    $scope.showQRCode = (peer) => {
+        $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers/" + peer + "/qr/b64", "method": "GET" }).then( (resp) => {
+            $uibModal.open({
+                template: "<div style='margin:10px;'><h2>Wireguard-Konfiguration \"" + peer + "\"</h2><img style='width:100%;' src='data:image/png;base64," + resp.data + "'/></div>",
+                size: 'mg'
+            });
+        });
+    }
+
+    $scope.create = () => {
+        messagebox.prompt(gettext('Name') + ": ").then( (msg) => {
+            $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers", "method": "POST", "data": { "name": msg.value } }).then( (resp) => {
+                notify.success(gettext("Created succesfully!"))
+                $scope.loadPeers();
+                $scope.askRestart();
+            });
+        });
+    }
+
+    $scope.delete = (peer) => {
+        messagebox.show({
+            text: gettext("Do you really want to delete this peer?"),
+            positive: gettext('Delete'),
+            negative: gettext('Cancel')
+        }).then( () => {
+            $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers/" + peer, "method": "DELETE" }).then( (resp) => {
+                notify.success(gettext("Deleted succesfully!"))
+                $scope.loadPeers();
+                $scope.askRestart();
+            });
+        });   
+    }
+
+    $scope.restart = () => {
+        messagebox.show({
+            text: gettext("Do you really want to restart the wireguard server? All clients have to reconnected!"),
+            positive: gettext('Restart'),
+            negative: gettext('Cancel')
+        }).then( () => {
+            $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/restart", "method": "GET" }).then( (resp) => {
+                notify.success(gettext("Restarted succesfully!"))
+                $scope.loadPeers();
+            });
+        });   
+    }
+
+    $scope.askRestart = () => {
+        messagebox.show({
+            text: gettext("The configuration has changed. Do you want to restart the server?"),
+            positive: gettext('Restart'),
+            negative: gettext('Cancel')
+        }).then( () => {
+            $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/restart", "method": "GET" }).then( (resp) => {
+                notify.success(gettext("Restarted succesfully!"))
+                $scope.loadPeers();
+            });
+        });   
+    }
+
+    $scope.import = () => {
+        $uibModal.open({
+            templateUrl: '/lmn_wireguard:resources/partial/import.modal.html',
+            controller: 'Lmn_wireguardImportModalController',
+            backdrop  : 'static',
+            size: 'mg',
+            scope: $scope, // https://stackoverflow.com/questions/30709962/reload-list-after-closing-modal
+        }).result.then((result) => {
+            if(result){
+                $scope.askRestart();
+            }
+            $scope.loadPeers();
+        });
+    }
+
+    $scope.loadPeers();
+});
+
+angular.module('lmn.wireguard').controller('Lmn_wireguardImportModalController', function($scope, $http, pageTitle, gettext, notify, $uibModalInstance) {
+
+    $scope.users = [];
+
+    $http.get('/api/lmn/sophomorixUsers/students').then( (resp) => {
+        $scope.users = $scope.users.concat(resp.data);
+    });
+
+    $http.get('/api/lmn/sophomorixUsers/teachers').then( (resp) => {
+        $scope.users = $scope.users.concat(resp.data);
+    });
+
+    $scope.checkUser = () => {
+
+        $scope.userprefix = "lmn-user_";
+
+        $scope.userstoimport = [];
+        $scope.peerstodelete = [];
+
+        for (let i = 0; i < $scope.users.length; i++) {
+            let result = false;
+            angular.forEach($scope.peers, function(element) {
+                if (($scope.userprefix + $scope.users[i].sAMAccountName) == element.name) {
+                    result = true;
+                }
+            });
+            if(!result) {
+                $scope.userstoimport.push($scope.users[i])
+            }
+        }
+
+        angular.forEach($scope.peers, function(element) {
+            let result = false;
+            if (!element.name.includes($scope.userprefix)) {
+                result = true;
+            }
+            else {
+                for (let i = 0; i < $scope.users.length; i++) {
+                    if (element.name == ($scope.userprefix + $scope.users[i].sAMAccountName)) {
+                        result = true;
+                    }
+                }
+            }
+            if(!result) {
+                $scope.peerstodelete.push(element)
+            }
+        });
+
+    }
+
+    $scope.run = (importonly) => {
+
+        $scope.importstatus = 0;
+        $scope.importmax = $scope.userstoimport.length;
+
+        for (let i = 0; i < $scope.userstoimport.length; i++) {
+            console.log("Create new peer for " + $scope.userprefix + $scope.userstoimport[i].sAMAccountName)
+            $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers", "method": "POST", "data": { "name": $scope.userprefix + $scope.userstoimport[i].sAMAccountName } }).then( (resp) => {
+                $scope.importstatus += 1;
+                $scope.importprogress = ($scope.importstatus / $scope.importmax) * 100;
+            });
+        }
+
+        if(!importonly) {
+            $scope.importmax += $scope.peerstodelete.length;
+            for (let i = 0; i < $scope.peerstodelete.length; i++) {
+                $http.post('/api/lmn/wireguard', { "url": "/api/wireguard/peers/" + $scope.peerstodelete[i].name, "method": "DELETE" }).then( (resp) => {
+                    $scope.importstatus += 1;
+                    $scope.importprogress = ($scope.importstatus / $scope.importmax) * 100;
+                });
+            }
+        }
+
+    }
+    
+    $scope.close = () => {
+        $uibModalInstance.close(!$scope.importstatus);
+    }
+
+});

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/js/module.es
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/js/module.es
@@ -1,0 +1,5 @@
+// the module should depend on 'core' to use the stock services & components
+angular.module('lmn.wireguard', [
+    'core',
+]);
+

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/js/routing.es
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/js/routing.es
@@ -1,0 +1,6 @@
+angular.module('lmn.wireguard').config(($routeProvider) => {
+    $routeProvider.when('/view/lmn/wireguard', {
+        templateUrl: '/lmn_wireguard:resources/partial/index.html',
+        controller: 'Lmn_wireguardIndexController',
+    });
+});

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/partial/import.modal.html
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/partial/import.modal.html
@@ -1,0 +1,47 @@
+<div class="modal-header">
+    <h3><span translate>Import users</span></h3>
+</div>
+<div class="modal-body">
+    <ol style="line-height: 1.5em;">
+        <li>Found {{users.length}} users on server <button class="btn btn-sm" ng:click="checkUser()">Check users</button></li>
+        <li>Found {{userstoimport.length}} users to import and {{peerstodelete.length}} users to delete              
+            <div ng:if="userstoimport.length > 0">
+                <h4>Users to import</h4>
+                <table class="table table-bordered" style="background-color: #2af9231c;">
+                    <tr>
+                        <th>Username</th>
+                        <th>Firstname</th>
+                        <th>Lastname</th>
+                    </tr>
+                    <tr ng:repeat="user in userstoimport">
+                        <td>{{user.sAMAccountName}}</td>
+                        <td>{{user.givenName}}</td>
+                        <td>{{user.sn}}</td>
+                    </tr>
+                </table>
+            </div>
+
+            <div ng:if="peerstodelete.length > 0">
+                <h4>Peers to delete</h4>
+                <table class="table table-bordered" style="background-color: #c202021c;">
+                    <tr>
+                        <th>Peer-Name</th>
+                    </tr>
+                    <tr ng:repeat="peer in peerstodelete">
+                        <td>{{peer.name}}</td>
+                    </tr>
+                </table>
+            </div>
+        </li>
+        <li>Run import or import and delete!</li>
+    </ol>
+    <br>
+    <div class="progress" ng:if="importstatus">
+        <div class="progress-bar progress-bar-striped" role="progressbar" ng-style="{'width': importprogress + '%'}" aria-valuenow="{{importprogress}}" aria-valuemin="0" aria-valuemax="100">{{importstatus}} / {{importmax}}</div>
+    </div>
+</div>
+<div class="modal-footer">
+    <button ng:disabled="!userstoimport || userstoimport.length == 0" ng:click="run(true)" class="btn btn-success" translate>Import</button>
+    <button ng:disabled="!userstoimport || peerstodelete.length == 0" ng:click="run()" class="btn btn-success" translate>Import + Delete</button>
+    <button ng:click="close()" class="btn btn-default" translate>Close</button>
+</div>

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/partial/index.html
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/resources/partial/index.html
@@ -1,0 +1,32 @@
+<h1>Wireguard</h1>
+<div class="alert alert-warning" role="alert" ng:if="!peers">
+    Connection to wireguard server is not possible! Please check the server or your configuration!
+</div>  
+<div ng:if="peers" style="margin-bottom: 100px;">
+    <div class="card" style="width: 100%;">
+        <ul class="list-group list-group-flush" ng:repeat="peer in peers">
+            <li class="list-group-item" ng:style="{ 'border-left' : (status[peer.name].status == 'connected') ? '7px solid green' : '7px solid red' }">
+                <div style="font-size: larger;font-weight: bold;">{{peer.name}}</div>
+                <div><b translate>Public-Key</b>: {{peer.public_key}} | <b translate>IP-Address</b>: {{peer.ip}}</div>
+                <div><b translate>Routes</b>: <span class="badge bg-secondary" ng:repeat="route in peer.routes">{{route}}</span></div>
+                <div ng:if="status[peer.name].status == 'connected'">
+                    <b translate>Endpoint</b>: {{status[peer.name].endpoint}}
+                    <b translate>Last Handshake</b>: {{status[peer.name].latest_handshake_difference | number:0}} <span translate></span>seconds ago</span> | 
+                    <i class="fa fa-arrow-down"></i> {{status[peer.name].transfer.received | number:2}} MiB | <i class="fa fa-arrow-up"></i> {{status[peer.name].transfer.send | number:2}} MiB
+                </div>
+                <div style="margin-top:10px;">
+                    <button ng:click="showConfig(peer.name)" class="btn btn-lmn"><span translate>Configuration</span></button>
+                    <button ng:click="showQRCode(peer.name)" class="btn btn-lmn"><span translate>Show QR-Code</span></button>
+                    <button ng:click="delete(peer.name)" class="btn btn-danger"><span translate>Delete</span></button>
+                </div>
+            </li>
+        </ul>
+    </div>
+</div>
+
+<floating-toolbar ng:if="peers">
+    <button ng:if="peers" ng:click="create()" class="btn btn-success"><i class="fa fa-plus" title="Add"></i></button>
+    <button ng:if="peers" ng:click="import()" class="btn btn-success"><i class="fa fa-upload" title="Import"></i></button>
+    <button ng:click="restart()" class="btn btn-danger pull-right"><i class="fa fa-power-off"></i> <span translate>Restart</span></button>
+    <button ng:click="loadStatus()" class="btn btn-lmn pull-right"><i class="fa fa-refresh"></i> <span translate>Query status</span></button>
+</floating-toolbar>

--- a/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/views.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_wireguard/views.py
@@ -1,0 +1,52 @@
+from jadi import component
+
+from aj.api.http import get, post, HttpPlugin
+from aj.auth import authorize
+from aj.api.endpoint import endpoint, EndpointError
+
+import requests
+import json
+
+@component(HttpPlugin)
+class Handler(HttpPlugin):
+    def __init__(self, context):
+        self.context = context
+
+    @post(r'/api/lmn/wireguard')
+    @endpoint(api=True)
+    def handle_api_lmn_wireguard(self, http_context):
+        url = http_context.json_body()['url']
+        method = http_context.json_body()['method']
+
+        try:
+
+            with open("/etc/linuxmuster/webui/wireguard/config.json") as f:
+                config = json.load(f)
+
+            if method == "GET":
+                    req = requests.get(config["url"] + url, headers={ "LMN-API-Secret": config["secret"] }, verify=False)
+                    if req.status_code == 200:
+                        return req.json()
+
+            elif method == "POST":
+                data = http_context.json_body()['data']
+                req = requests.post(config["url"] + url, json.dumps(data), headers={ "LMN-API-Secret": config["secret"] }, verify=False)
+                if req.status_code == 200:
+                    return req.json()
+
+            elif method == "PUT":
+                data = http_context.json_body()['data']
+                req = requests.put(config["url"] + url, data, headers={ "LMN-API-Secret": config["secret"] }, verify=False)
+                if req.status_code == 200:
+                    return req.json()
+
+            elif method == "DELETE":
+                req = requests.delete(config["url"] + url, headers={ "LMN-API-Secret": config["secret"] }, verify=False)
+                if req.status_code == 200:
+                    return req.json()
+
+            return False
+        
+        except:
+
+            return False


### PR DESCRIPTION
The plugin was developed a while ago and can now be integrated into the WebUI (if desired). Where it can be configured and activated is documented in the README. The corresponding backend will also be released in the coming days.

Here are a few images:

![grafik](https://github.com/user-attachments/assets/fc55d079-b7be-4dc1-8b18-4180359dea8a)

![grafik](https://github.com/user-attachments/assets/e8d9aced-7714-40db-91ae-7c7069fe5e18)
