### PR TITLE
Fix school context reference for teachers' passwords

### DIFF
--- a/usr/lib/linuxmuster-webui/plugins/lmn_users/views/passwords.py
+++ b/usr/lib/linuxmuster-webui/plugins/lmn_users/views/passwords.py
@@ -201,7 +201,7 @@ class Handler(HttpPlugin):
             if self.context.schoolmgr.school == 'default-school':
                 classes.append('teachers')
             else:
-                classes.append(f'{school}-teachers')
+                classes.append(f'{self.context.schoolmgr.school}-teachers')
 
         else:
             schoolclasses_user = self.context.ldapreader.schoolget(f'/users/{self.context.identity}').get('schoolclasses', [])


### PR DESCRIPTION
Variable school is not defined so an error occours when using this as admin in a multischool environment.